### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/wolfskaempf/leipzig.png?label=ready&title=Ready)](https://waffle.io/wolfskaempf/leipzig)
 # leipzig
 A web app for the 80th International Session of the European Youth Parliament
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/wolfskaempf/leipzig

This was requested by a real person (user wolfskaempf) on waffle.io, we're not trying to spam you.
